### PR TITLE
MERN migration: Express + MongoDB backend, frontend repointed off Fir…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,12 @@ dist/
 
 # dependencies
 /node_modules
+server/node_modules
 /.pnp
 .pnp.js
+
+# keep the server's lockfile for reproducible backend installs
+!server/package-lock.json
 
 # testing
 /coverage

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,6 @@
+# USE_MEMORY_DB=true runs an in-process MongoDB (no Docker/install). Set to false
+# and provide MONGO_URI to use Docker locally or Cosmos DB later.
+USE_MEMORY_DB=true
+PORT=4000
+MONGO_URI=mongodb://localhost:27017/smooches
+CLIENT_ORIGIN=http://localhost:3000

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,2445 @@
+{
+  "name": "smooches-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "smooches-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
+        "express": "^4.19.2",
+        "mongoose": "^8.6.0",
+        "smootches-inc": "file:.."
+      },
+      "devDependencies": {
+        "@types/cors": "^2.8.17",
+        "@types/express": "^4.17.21",
+        "@types/node": "^22.5.0",
+        "mongodb-memory-server": "^11.2.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.3"
+      }
+    },
+    "..": {
+      "name": "smootches-inc",
+      "version": "0.1.0",
+      "dependencies": {
+        "@fortawesome/fontawesome-free": "^5.15.1",
+        "@material-ui/core": "^4.11.2",
+        "@tanstack/react-query": "^4.44.0",
+        "bootstrap": "^4.5.3",
+        "firebase": "^8.2.1",
+        "formik": "^2.4.9",
+        "prop-types": "^15.7.2",
+        "re-base": "^4.0.0",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1",
+        "react-router-dom": "^5.2.0",
+        "reactstrap": "^8.7.1",
+        "web-vitals": "^0.2.4"
+      },
+      "devDependencies": {
+        "@types/react": "^17.0.93",
+        "@types/react-dom": "^17.0.26",
+        "@types/react-router-dom": "^5.3.3",
+        "@vitejs/plugin-react": "^4.3.3",
+        "eslint-config-airbnb-base": "^14.2.0",
+        "eslint-config-prettier": "^6.15.0",
+        "sass": "^1.62.0",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.10",
+        "vitest": "^2.1.9"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
+      "integrity": "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
+      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongodb-memory-server": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-11.2.0.tgz",
+      "integrity": "sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "11.2.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-11.2.0.tgz",
+      "integrity": "sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.4.3",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.16.0",
+        "https-proxy-agent": "^7.0.6",
+        "mongodb": "^7.2.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.7.3",
+        "tar-stream": "^3.1.8",
+        "tslib": "^2.8.1",
+        "yauzl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/@types/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/bson": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
+      "integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.4.0.tgz",
+      "integrity": "sha512-giySkkdYiwoBFo/oCc8nzov3xOYZ/sB8OpAYk5GINRLEjVw0LDsm8xgQL0XMTyU4extQlDZjhdUr1ZEwKFaazw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "snappy": "^7.3.2",
+        "socks": "^2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb-connection-string-url": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mongoose": {
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.1.tgz",
+      "integrity": "sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^6.10.4",
+        "kareem": "2.6.3",
+        "mongodb": "~6.20.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/mquery/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mquery/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/new-find-package-json/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/new-find-package-json/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
+    },
+    "node_modules/smootches-inc": {
+      "resolved": "..",
+      "link": true
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "smooches-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "seed": "tsx src/seed.ts"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "mongoose": "^8.6.0",
+    "smootches-inc": "file:.."
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.5.0",
+    "mongodb-memory-server": "^11.2.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,0 +1,29 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+let memoryServer: MongoMemoryServer | undefined;
+
+/**
+ * Connects Mongoose to MongoDB and returns the URI actually used.
+ * - If `uri` is provided -> connects to that real MongoDB (Docker / Atlas / Cosmos).
+ * - If `uri` is empty -> starts an in-process MongoDB (mongodb-memory-server),
+ *   which needs no install. Data is ephemeral (gone when the process exits), which
+ *   is fine in dev because we re-seed on startup.
+ * Swapping to Cosmos later is just providing a real `uri` (+ retryWrites=false).
+ */
+export async function connectToDatabase(uri?: string): Promise<string> {
+  let connectionUri = uri;
+
+  if (!connectionUri) {
+    memoryServer = await MongoMemoryServer.create();
+    connectionUri = memoryServer.getUri();
+    console.log('[db] started in-memory MongoDB (ephemeral) — no external Mongo configured');
+  }
+
+  mongoose.connection.on('connected', () => console.log('[db] connected to MongoDB'));
+  mongoose.connection.on('error', (err) => console.error('[db] connection error:', err.message));
+  mongoose.connection.on('disconnected', () => console.warn('[db] disconnected'));
+
+  await mongoose.connect(connectionUri);
+  return connectionUri;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,63 @@
+import 'dotenv/config';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import cors from 'cors';
+import { connectToDatabase } from './db';
+import { seedDatabase } from './seed';
+import servicesRouter from './routes/services';
+import todosRouter from './routes/todos';
+import reviewsRouter from './routes/reviews';
+import usersRouter from './routes/users';
+import userjoinsRouter from './routes/userjoins';
+
+const app = express();
+
+// --- Middleware: runs on every request, top to bottom ---
+// CORS lets the React app (a different origin/port) call this API from the browser.
+app.use(cors({ origin: process.env.CLIENT_ORIGIN ?? 'http://localhost:3000' }));
+// Parses a JSON request body into `req.body`.
+app.use(express.json());
+
+// --- Routes ---
+// A tiny health check so we can confirm the server is up independent of the DB.
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok', time: new Date().toISOString() });
+});
+
+// Feature routes mount here. Each resource gets its own router.
+app.use('/api/services', servicesRouter);
+app.use('/api/todos', todosRouter);
+app.use('/api/reviews', reviewsRouter);
+app.use('/api/users', usersRouter);
+app.use('/api/userjoins', userjoinsRouter);
+
+// Error-handling middleware: Express recognizes it by its 4 arguments. Anything
+// passed to next(err) (incl. async errors via asyncHandler) lands here.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+  console.error('[error]', err);
+  res.status(500).json({ error: err.message || 'Internal server error' });
+});
+
+const PORT = Number(process.env.PORT ?? 4000);
+const MONGO_URI = process.env.MONGO_URI ?? 'mongodb://localhost:27017/smooches';
+
+// Start the HTTP server first so /api/health works even before Mongo is up,
+// then connect to the database (logs a clear message if Mongo isn't running yet).
+app.listen(PORT, () => {
+  console.log(`[server] listening on http://localhost:${PORT}`);
+});
+
+// USE_MEMORY_DB=true -> spin up an in-process MongoDB (no Docker/install needed).
+// Otherwise connect to the real MONGO_URI (Docker now, Cosmos later).
+const useMemoryDb = process.env.USE_MEMORY_DB === 'true';
+
+connectToDatabase(useMemoryDb ? undefined : MONGO_URI)
+  .then(async () => {
+    // The in-memory DB starts empty on every boot, so populate it from the seed.
+    if (useMemoryDb) {
+      await seedDatabase();
+    }
+  })
+  .catch((err) => {
+    console.error('[server] could not connect to MongoDB:', err.message);
+  });

--- a/server/src/lib/asyncHandler.ts
+++ b/server/src/lib/asyncHandler.ts
@@ -1,0 +1,11 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Express 4 does not catch errors thrown inside async route handlers, so an
+ * unhandled rejection would leave the request hanging. This wrapper catches any
+ * rejection and forwards it to Express's error-handling middleware via next().
+ */
+export const asyncHandler =
+  (fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown>): RequestHandler =>
+  (req, res, next) =>
+    Promise.resolve(fn(req, res, next)).catch(next);

--- a/server/src/lib/baseSchema.ts
+++ b/server/src/lib/baseSchema.ts
@@ -1,0 +1,32 @@
+import { Schema, Types, type SchemaDefinition } from 'mongoose';
+
+/**
+ * Builds a schema whose `_id` is a String (so it can hold the legacy Firebase
+ * push-id during migration) and exposes a `firebaseKey` virtual === `_id`.
+ *
+ * Why: the React app addresses records by `firebaseKey` and cross-references them
+ * by it (e.g. todo.taskId === service.firebaseKey). Making `_id` BE that key lets
+ * the standard `findById` routes work with the keys the frontend already sends,
+ * and `res.json` returns a `firebaseKey` field the frontend reads. New documents
+ * get a generated id.
+ */
+export function createSchema(definition: SchemaDefinition) {
+  const schema = new Schema(
+    {
+      _id: { type: String, default: () => new Types.ObjectId().toString() },
+      ...definition,
+    },
+    {
+      timestamps: true,
+      id: false,
+      toJSON: { virtuals: true },
+      toObject: { virtuals: true },
+    },
+  );
+
+  schema.virtual('firebaseKey').get(function (this: { _id: string }) {
+    return this._id;
+  });
+
+  return schema;
+}

--- a/server/src/models/Review.ts
+++ b/server/src/models/Review.ts
@@ -1,0 +1,15 @@
+import { model, InferSchemaType } from 'mongoose';
+import { createSchema } from '../lib/baseSchema';
+
+const reviewSchema = createSchema({
+  uid: { type: String, required: true, index: true },
+  serviceid: String, // references a Service _id/firebaseKey
+  toDoid: String, // references a ToDo _id/firebaseKey
+  reviewStars: String,
+  reviewText: String,
+  // Legacy mixed epoch-millis/date strings; Mongoose casts to String here.
+  dateTime: String,
+});
+
+export type ReviewDoc = InferSchemaType<typeof reviewSchema>;
+export const Review = model('Review', reviewSchema);

--- a/server/src/models/Service.ts
+++ b/server/src/models/Service.ts
@@ -1,0 +1,13 @@
+import { model, InferSchemaType } from 'mongoose';
+import { createSchema } from '../lib/baseSchema';
+
+// `_id` holds the firebaseKey (see baseSchema). `uid` is the owner.
+const serviceSchema = createSchema({
+  uid: { type: String, required: true, index: true },
+  name: { type: String, required: true },
+  description: { type: String, default: '' },
+  offerDescription: { type: String, default: '' },
+});
+
+export type ServiceDoc = InferSchemaType<typeof serviceSchema>;
+export const Service = model('Service', serviceSchema);

--- a/server/src/models/ToDo.ts
+++ b/server/src/models/ToDo.ts
@@ -1,0 +1,16 @@
+import { model, InferSchemaType } from 'mongoose';
+import { createSchema } from '../lib/baseSchema';
+
+const toDoSchema = createSchema({
+  uid: { type: String, required: true, index: true }, // owner the task is assigned to
+  taskId: String, // references a Service _id/firebaseKey
+  requesterId: String,
+  requestedTime: String,
+  completedTime: String,
+  reviewId: String,
+  status: String,
+  hidden: Boolean,
+});
+
+export type ToDoDoc = InferSchemaType<typeof toDoSchema>;
+export const ToDo = model('ToDo', toDoSchema);

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -1,0 +1,13 @@
+import { model, InferSchemaType } from 'mongoose';
+import { createSchema } from '../lib/baseSchema';
+
+const userSchema = createSchema({
+  uid: { type: String, required: true, index: true }, // Firebase Auth uid (cross-entity join key)
+  name: String,
+  email: String,
+  image: String,
+  lastSignInTime: String,
+});
+
+export type UserDoc = InferSchemaType<typeof userSchema>;
+export const User = model('User', userSchema);

--- a/server/src/models/UserJoin.ts
+++ b/server/src/models/UserJoin.ts
@@ -1,0 +1,11 @@
+import { model, InferSchemaType } from 'mongoose';
+import { createSchema } from '../lib/baseSchema';
+
+const userJoinSchema = createSchema({
+  user1FBKey: String, // a user's uid
+  user2FBKey: String, // the partner's uid
+  confirm: Boolean,
+});
+
+export type UserJoinDoc = InferSchemaType<typeof userJoinSchema>;
+export const UserJoin = model('UserJoin', userJoinSchema);

--- a/server/src/routes/reviews.ts
+++ b/server/src/routes/reviews.ts
@@ -1,0 +1,60 @@
+import { Router } from 'express';
+import { Review } from '../models/Review';
+import { asyncHandler } from '../lib/asyncHandler';
+
+const router = Router();
+
+// GET /api/reviews         -> all reviews
+// GET /api/reviews?uid=xxx -> reviews written by that uid
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const filter = req.query.uid ? { uid: String(req.query.uid) } : {};
+    res.json(await Review.find(filter));
+  }),
+);
+
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const review = await Review.findById(req.params.id);
+    if (!review) {
+      res.status(404).json({ error: 'Review not found' });
+      return;
+    }
+    res.json(review);
+  }),
+);
+
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    res.status(201).json(await Review.create(req.body));
+  }),
+);
+
+router.patch(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const updated = await Review.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!updated) {
+      res.status(404).json({ error: 'Review not found' });
+      return;
+    }
+    res.json(updated);
+  }),
+);
+
+router.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const deleted = await Review.findByIdAndDelete(req.params.id);
+    if (!deleted) {
+      res.status(404).json({ error: 'Review not found' });
+      return;
+    }
+    res.status(204).end();
+  }),
+);
+
+export default router;

--- a/server/src/routes/services.ts
+++ b/server/src/routes/services.ts
@@ -1,0 +1,66 @@
+import { Router } from 'express';
+import { Service } from '../models/Service';
+import { asyncHandler } from '../lib/asyncHandler';
+
+// A Router is a mini Express app — a group of related routes we mount under a
+// base path (here, /api/services) in index.ts.
+const router = Router();
+
+// GET /api/services  -> list all services
+router.get(
+  '/',
+  asyncHandler(async (_req, res) => {
+    const services = await Service.find();
+    res.json(services);
+  }),
+);
+
+// GET /api/services/:id  -> one service by its MongoDB _id
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const service = await Service.findById(req.params.id);
+    if (!service) {
+      res.status(404).json({ error: 'Service not found' });
+      return;
+    }
+    res.json(service);
+  }),
+);
+
+// POST /api/services  -> create (body is the new service)
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const created = await Service.create(req.body);
+    res.status(201).json(created);
+  }),
+);
+
+// PATCH /api/services/:id  -> partial update
+router.patch(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const updated = await Service.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!updated) {
+      res.status(404).json({ error: 'Service not found' });
+      return;
+    }
+    res.json(updated);
+  }),
+);
+
+// DELETE /api/services/:id
+router.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const deleted = await Service.findByIdAndDelete(req.params.id);
+    if (!deleted) {
+      res.status(404).json({ error: 'Service not found' });
+      return;
+    }
+    res.status(204).end();
+  }),
+);
+
+export default router;

--- a/server/src/routes/todos.ts
+++ b/server/src/routes/todos.ts
@@ -1,0 +1,66 @@
+import { Router } from 'express';
+import { ToDo } from '../models/ToDo';
+import { asyncHandler } from '../lib/asyncHandler';
+
+const router = Router();
+
+// GET /api/todos          -> all todos
+// GET /api/todos?uid=xxx  -> only todos owned by that uid (req.query holds ?key=value)
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const filter = req.query.uid ? { uid: String(req.query.uid) } : {};
+    const todos = await ToDo.find(filter);
+    res.json(todos);
+  }),
+);
+
+// GET /api/todos/:id
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const todo = await ToDo.findById(req.params.id);
+    if (!todo) {
+      res.status(404).json({ error: 'ToDo not found' });
+      return;
+    }
+    res.json(todo);
+  }),
+);
+
+// POST /api/todos
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const created = await ToDo.create(req.body);
+    res.status(201).json(created);
+  }),
+);
+
+// PATCH /api/todos/:id
+router.patch(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const updated = await ToDo.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!updated) {
+      res.status(404).json({ error: 'ToDo not found' });
+      return;
+    }
+    res.json(updated);
+  }),
+);
+
+// DELETE /api/todos/:id
+router.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const deleted = await ToDo.findByIdAndDelete(req.params.id);
+    if (!deleted) {
+      res.status(404).json({ error: 'ToDo not found' });
+      return;
+    }
+    res.status(204).end();
+  }),
+);
+
+export default router;

--- a/server/src/routes/userjoins.ts
+++ b/server/src/routes/userjoins.ts
@@ -1,0 +1,62 @@
+import { Router } from 'express';
+import { UserJoin } from '../models/UserJoin';
+import { asyncHandler } from '../lib/asyncHandler';
+
+const router = Router();
+
+// GET /api/userjoins         -> all join records
+// GET /api/userjoins?uid=xxx -> joins where that uid is EITHER participant
+//   ($or lets one query match user1FBKey or user2FBKey, matching getJoinedUser).
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const uid = req.query.uid ? String(req.query.uid) : undefined;
+    const filter = uid ? { $or: [{ user1FBKey: uid }, { user2FBKey: uid }] } : {};
+    res.json(await UserJoin.find(filter));
+  }),
+);
+
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const join = await UserJoin.findById(req.params.id);
+    if (!join) {
+      res.status(404).json({ error: 'UserJoin not found' });
+      return;
+    }
+    res.json(join);
+  }),
+);
+
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    res.status(201).json(await UserJoin.create(req.body));
+  }),
+);
+
+router.patch(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const updated = await UserJoin.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!updated) {
+      res.status(404).json({ error: 'UserJoin not found' });
+      return;
+    }
+    res.json(updated);
+  }),
+);
+
+router.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const deleted = await UserJoin.findByIdAndDelete(req.params.id);
+    if (!deleted) {
+      res.status(404).json({ error: 'UserJoin not found' });
+      return;
+    }
+    res.status(204).end();
+  }),
+);
+
+export default router;

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -1,0 +1,60 @@
+import { Router } from 'express';
+import { User } from '../models/User';
+import { asyncHandler } from '../lib/asyncHandler';
+
+const router = Router();
+
+// GET /api/users         -> all users
+// GET /api/users?uid=xxx -> the user(s) with that Firebase Auth uid
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const filter = req.query.uid ? { uid: String(req.query.uid) } : {};
+    res.json(await User.find(filter));
+  }),
+);
+
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const user = await User.findById(req.params.id);
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+    res.json(user);
+  }),
+);
+
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    res.status(201).json(await User.create(req.body));
+  }),
+);
+
+router.patch(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const updated = await User.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!updated) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+    res.json(updated);
+  }),
+);
+
+router.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const deleted = await User.findByIdAndDelete(req.params.id);
+    if (!deleted) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+    res.status(204).end();
+  }),
+);
+
+export default router;

--- a/server/src/seed-data.demo.json
+++ b/server/src/seed-data.demo.json
@@ -1,0 +1,526 @@
+{
+  "review": {
+    "-MOoExvgIGaDPDCXMRDb": {
+      "dateTime": 1608268094536,
+      "firebaseKey": "",
+      "reviewStars": "3",
+      "reviewText": "Good job! Thanks!",
+      "serviceid": "-MOdJuQoyPb_TS91zzUy",
+      "toDoid": "-MOoEis9xOKfQt-b2-kN",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MOtIpyVSNwoFkw3YAbJ": {
+      "dateTime": 1608352958350,
+      "firebaseKey": "-MOtIpyVSNwoFkw3YAbJ",
+      "reviewStars": "5",
+      "reviewText": "You did such a great job of cleaning my desk.",
+      "serviceid": "-MOoDVOnKe6HnlPhEQVQ",
+      "toDoid": "-MOtIMtNTlgCgXD7BzC7",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MOuwwnvW42lWIf_eGDc": {
+      "dateTime": 1608380551982,
+      "firebaseKey": "-MOuwwnvW42lWIf_eGDc",
+      "reviewStars": "4",
+      "reviewText": "That coffee was really good!",
+      "serviceid": "-MOdJuQoyPb_TS91zzUy",
+      "toDoid": "-MOo3ljv1Kh9HyjTh5W2",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MOvaKszykcGuNIzzJFE": {
+      "dateTime": 1608391401900,
+      "firebaseKey": "-MOvaKszykcGuNIzzJFE",
+      "reviewStars": "5",
+      "reviewText": "You did such a great job on vacuuming",
+      "serviceid": "-MOv_w_YC27s7sPt9GQK",
+      "toDoid": "-MOva0mOWAGcSVx-Iutp",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MPLVSn4iN4D7SAiy8F_": {
+      "dateTime": 1608842847122,
+      "firebaseKey": "-MPLVSn4iN4D7SAiy8F_",
+      "reviewStars": "5",
+      "reviewText": "Wonderful!!!",
+      "serviceid": "-MOdLx-YJQdtYIyaCHnZ",
+      "toDoid": "-MOdOB3JbVsIdyKYkfLB",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MPLVZILYanCuBkHvSYm": {
+      "dateTime": 1608842878086,
+      "firebaseKey": "-MPLVZILYanCuBkHvSYm",
+      "reviewStars": "5",
+      "reviewText": "Great Job!!!!",
+      "serviceid": "-MOoDKOnkkKQOzkx7ufC",
+      "toDoid": "-MOoE-XY9qgVYScX9DY9",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MPPl05A4Fbyc_67Dqn4": {
+      "dateTime": 1608914293273,
+      "firebaseKey": "-MPPl05A4Fbyc_67Dqn4",
+      "reviewStars": "5",
+      "reviewText": "The Car looks amazing!",
+      "serviceid": "-MP6rXExf5Rn-JGgBalR",
+      "toDoid": "-MPPjg_JrG0F4QRl9Nb8",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MQFPbGyz5C0wmGK3is6": {
+      "dateTime": "Mon Jan 04 2021",
+      "firebaseKey": "-MQFPbGyz5C0wmGK3is6",
+      "reviewStars": "5",
+      "reviewText": "Thank you for bringing me coffee!",
+      "serviceid": "-MOoDVOnKe6HnlPhEQVQ",
+      "toDoid": "-MPQdeqiBtHSzZ6FsAG_",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MQFaURGeP4EY9NkmSyJ": {
+      "dateTime": "Mon Jan 04 2021",
+      "firebaseKey": "-MQFaURGeP4EY9NkmSyJ",
+      "reviewStars": "3",
+      "reviewText": "Thanks for making me toast, just next time please put the toaster on the 3rd setting. ",
+      "serviceid": "-MOoDKOnkkKQOzkx7ufC",
+      "toDoid": "-MPHwiJFCKMH-jdq_TTN",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MQFars5_aXDDXaHpmLb": {
+      "dateTime": "Mon Jan 04 2021",
+      "firebaseKey": "-MQFars5_aXDDXaHpmLb",
+      "reviewStars": "",
+      "reviewText": "You did a good job! Also thanks for leaving the candy!",
+      "serviceid": "-MOoDVOnKe6HnlPhEQVQ",
+      "toDoid": "-MQAWljEW0dHJVYs5EwB",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MQFjRLR37YNri3-_HCB": {
+      "dateTime": "Mon Jan 04 2021",
+      "firebaseKey": "-MQFjRLR37YNri3-_HCB",
+      "reviewStars": "3",
+      "reviewText": "It was okay, but next time please clean the inside of the windows.",
+      "serviceid": "-MP6rXExf5Rn-JGgBalR",
+      "toDoid": "-MQFfF4OAECwlND7XqI-",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MQFkAAh-Ql7XejhCpCj": {
+      "dateTime": "Mon Jan 04 2021",
+      "firebaseKey": "-MQFkAAh-Ql7XejhCpCj",
+      "reviewStars": "4",
+      "reviewText": "Good job, can you get the inside of the couch too?",
+      "serviceid": "-MOv_w_YC27s7sPt9GQK",
+      "toDoid": "-MQFjpNjeZszVtFmf_8-",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MQFkBDnJ19qBzMFWKen": {
+      "dateTime": "Mon Jan 04 2021",
+      "firebaseKey": "-MQFkBDnJ19qBzMFWKen",
+      "reviewStars": "4",
+      "reviewText": "Good job, can you get the inside of the couch too?",
+      "serviceid": "-MOv_w_YC27s7sPt9GQK",
+      "toDoid": "-MQFjpNjeZszVtFmf_8-",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MQFkFG8uOtxCEwilKrO": {
+      "dateTime": "Mon Jan 04 2021",
+      "firebaseKey": "-MQFkFG8uOtxCEwilKrO",
+      "reviewStars": "5",
+      "reviewText": "Thanks. ",
+      "serviceid": "-MOdLx-YJQdtYIyaCHnZ",
+      "toDoid": "-MQFjpRiiHIcAgKe43Bw",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MQK49f-c-4jjKoZ0Whk": {
+      "dateTime": "Tue Jan 05 2021",
+      "firebaseKey": "-MQK49f-c-4jjKoZ0Whk",
+      "reviewStars": "5",
+      "reviewText": "Thanks for bringing that coffee it was great!",
+      "serviceid": "-MOdJuQoyPb_TS91zzUy",
+      "toDoid": "-MQK3zcLir4ourxlEWbC",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MQrFypMeEEWkpH94X4O": {
+      "dateTime": "Tue Jan 12 2021",
+      "firebaseKey": "-MQrFypMeEEWkpH94X4O",
+      "reviewStars": "",
+      "reviewText": "You did such a great job!",
+      "serviceid": "-MOdJuQoyPb_TS91zzUy",
+      "toDoid": "-MQIYTQg5PvxcLh6q7zC",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MSrw-65xYq9ufKAbnx1": {
+      "dateTime": "Sat Feb 06 2021",
+      "firebaseKey": "-MSrw-65xYq9ufKAbnx1",
+      "reviewStars": "5",
+      "reviewText": "Great job on the coffee!",
+      "serviceid": "-MOdJuQoyPb_TS91zzUy",
+      "toDoid": "-MSrvbsyvqcSqqH5l8YT",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    }
+  },
+  "services": {
+    "-MOdJuQoyPb_TS91zzUy": {
+      "description": "Pikes place, 2 sugars and 1 cream",
+      "firebaseKey": "-MOdJuQoyPb_TS91zzUy",
+      "name": "Bring coffee to work",
+      "offerDescription": "",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MOdLx-YJQdtYIyaCHnZ": {
+      "description": "15 minutes",
+      "firebaseKey": "-MOdLx-YJQdtYIyaCHnZ",
+      "name": "Get a massage",
+      "offerDescription": "15 ",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MOoDKOnkkKQOzkx7ufC": {
+      "description": "Eggs, bacon, toast",
+      "firebaseKey": "-MOoDKOnkkKQOzkx7ufC",
+      "name": "Make me breakfast",
+      "offerDescription": "Eggs, bacon, toast",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MOoDVOnKe6HnlPhEQVQ": {
+      "description": "Put your coffee cups in sink ",
+      "firebaseKey": "-MOoDVOnKe6HnlPhEQVQ",
+      "name": "Clean your Desk ",
+      "offerDescription": "Clean Desk ",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MOv_w_YC27s7sPt9GQK": {
+      "description": "Under the couch too",
+      "firebaseKey": "-MOv_w_YC27s7sPt9GQK",
+      "name": "Vacuum the livingroom",
+      "offerDescription": "",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MP6rXExf5Rn-JGgBalR": {
+      "description": "Full service car wash",
+      "firebaseKey": "-MP6rXExf5Rn-JGgBalR",
+      "name": "Clean the car",
+      "offerDescription": "",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MQrFIu8CVgD3oAoUcm9": {
+      "description": "pepperoni",
+      "firebaseKey": "-MQrFIu8CVgD3oAoUcm9",
+      "name": "Bring me pizza",
+      "offerDescription": "",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MSrvpwyGWd9KdzsQmKW": {
+      "description": "use windex",
+      "firebaseKey": "-MSrvpwyGWd9KdzsQmKW",
+      "name": "Wash the windows",
+      "offerDescription": "",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    }
+  },
+  "todo": {
+    "-MOdO-kTJK0ZhaK4bNme": {
+      "completedTime": "2020-12-18T04:59:32.041Z",
+      "firebaseKey": "-MOdO-kTJK0ZhaK4bNme",
+      "hidden": true,
+      "requestedTime": "Tue Dec 15 2020",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MOdJuQoyPb_TS91zzUy",
+      "status": "completed",
+      "taskId": "-MOdJuQoyPb_TS91zzUy",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MOdO-k_VMmD1FW0Ls4b": {
+      "completedTime": "2020-12-18T04:59:33.341Z",
+      "firebaseKey": "-MOdO-k_VMmD1FW0Ls4b",
+      "hidden": true,
+      "requestedTime": "Tue Dec 15 2020",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MOdJuQoyPb_TS91zzUy",
+      "status": "completed",
+      "taskId": "-MOdKYj2QXbig1ZecRfR",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MOdOB3JbVsIdyKYkfLB": {
+      "completedTime": "2020-12-18T00:20:34.357Z",
+      "firebaseKey": "-MOdOB3JbVsIdyKYkfLB",
+      "hidden": true,
+      "requestedTime": "Tue Dec 15 2020",
+      "requesterId": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2",
+      "reviewId": "-MPLVSn4iN4D7SAiy8F_",
+      "status": "completed",
+      "taskId": "-MOdLx-YJQdtYIyaCHnZ",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MOo3ljv1Kh9HyjTh5W2": {
+      "completedTime": "2020-12-18T04:20:15.199Z",
+      "firebaseKey": "-MOo3ljv1Kh9HyjTh5W2",
+      "hidden": true,
+      "requestedTime": "Thu Dec 17 2020",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MOdJuQoyPb_TS91zzUy",
+      "status": "completed",
+      "taskId": "-MOdJuQoyPb_TS91zzUy",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MOoE-XY9qgVYScX9DY9": {
+      "completedTime": "2020-12-18T05:04:41.101Z",
+      "firebaseKey": "-MOoE-XY9qgVYScX9DY9",
+      "hidden": true,
+      "requestedTime": "Thu Dec 17 2020",
+      "requesterId": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2",
+      "reviewId": "-MPLVZILYanCuBkHvSYm",
+      "status": "completed",
+      "taskId": "-MOoDKOnkkKQOzkx7ufC",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MOoEis9xOKfQt-b2-kN": {
+      "completedTime": "2020-12-18T05:07:34.779Z",
+      "firebaseKey": "-MOoEis9xOKfQt-b2-kN",
+      "hidden": true,
+      "requestedTime": "Thu Dec 17 2020",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MOdJuQoyPb_TS91zzUy",
+      "status": "pending",
+      "taskId": "-MOdJuQoyPb_TS91zzUy",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MOtIMtNTlgCgXD7BzC7": {
+      "completedTime": "2020-12-19T04:41:52.522Z",
+      "firebaseKey": "-MOtIMtNTlgCgXD7BzC7",
+      "hidden": true,
+      "requestedTime": "Fri Dec 18 2020",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MOdJuQoyPb_TS91zzUy",
+      "status": "completed",
+      "taskId": "-MOoDVOnKe6HnlPhEQVQ",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MOtIMtVmuZHhNPYic1S": {
+      "completedTime": "2020-12-25T16:10:46.667Z",
+      "firebaseKey": "-MOtIMtVmuZHhNPYic1S",
+      "hidden": true,
+      "requestedTime": "Fri Dec 18 2020",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MOdJuQoyPb_TS91zzUy",
+      "status": "completed",
+      "taskId": "-MOdJuQoyPb_TS91zzUy",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MOtS_pCxhcn6ptMmXPk": {
+      "completedTime": "2020-12-26T18:01:59.748Z",
+      "firebaseKey": "-MOtS_pCxhcn6ptMmXPk",
+      "hidden": true,
+      "requestedTime": "Fri Dec 18 2020",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MOdJuQoyPb_TS91zzUy",
+      "status": "completed",
+      "taskId": "-MOdJuQoyPb_TS91zzUy",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MOva0mOWAGcSVx-Iutp": {
+      "completedTime": "2020-12-19T15:22:54.043Z",
+      "firebaseKey": "-MOva0mOWAGcSVx-Iutp",
+      "hidden": true,
+      "requestedTime": "Sat Dec 19 2020",
+      "requesterId": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2",
+      "reviewId": "-MOdJuQoyPb_TS91zzUy",
+      "status": "completed",
+      "taskId": "-MOv_w_YC27s7sPt9GQK",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MPHmMft2yC-8pvDz0iq": {
+      "completedTime": "2021-01-05T02:30:58.020Z",
+      "firebaseKey": "-MPHmMft2yC-8pvDz0iq",
+      "hidden": true,
+      "requestedTime": "Wed Dec 23 2020",
+      "requesterId": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2",
+      "reviewId": "-MOdJuQoyPb_TS91zzUy",
+      "status": "completed",
+      "taskId": "-MOdLx-YJQdtYIyaCHnZ",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MPHvUCWlWf6u3JO-WUb": {
+      "completedTime": "2021-01-05T02:38:44.668Z",
+      "firebaseKey": "-MPHvUCWlWf6u3JO-WUb",
+      "hidden": true,
+      "requestedTime": "Wed Dec 23 2020",
+      "requesterId": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2",
+      "reviewId": "-MOdJuQoyPb_TS91zzUy",
+      "status": "completed",
+      "taskId": "-MOdLx-YJQdtYIyaCHnZ",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MPHwiJFCKMH-jdq_TTN": {
+      "completedTime": "2021-01-05T03:30:31.757Z",
+      "firebaseKey": "-MPHwiJFCKMH-jdq_TTN",
+      "hidden": true,
+      "requestedTime": "Wed Dec 23 2020",
+      "requesterId": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2",
+      "reviewId": "-MQFaURGeP4EY9NkmSyJ",
+      "status": "completed",
+      "taskId": "-MOoDKOnkkKQOzkx7ufC",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MPLVnQLx4xo3gC6SCyl": {
+      "completedTime": "2021-01-05T02:39:33.545Z",
+      "firebaseKey": "-MPLVnQLx4xo3gC6SCyl",
+      "hidden": true,
+      "requestedTime": "Thu Dec 24 2020",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MOdJuQoyPb_TS91zzUy",
+      "status": "completed",
+      "taskId": "-MOdJuQoyPb_TS91zzUy",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MPPjg_JrG0F4QRl9Nb8": {
+      "completedTime": "2020-12-25T16:37:38.565Z",
+      "firebaseKey": "-MPPjg_JrG0F4QRl9Nb8",
+      "hidden": true,
+      "requestedTime": "Fri Dec 25 2020",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MPPl05A4Fbyc_67Dqn4",
+      "status": "pending",
+      "taskId": "-MP6rXExf5Rn-JGgBalR",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MPQdGy2ORaIibhGLJ69": {
+      "completedTime": "",
+      "firebaseKey": "-MPQdGy2ORaIibhGLJ69",
+      "requestedTime": "Fri Dec 25 2020",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "",
+      "status": "pending",
+      "taskId": "-MP6rXExf5Rn-JGgBalR",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MPQdeqiBtHSzZ6FsAG_": {
+      "completedTime": "2020-12-26T18:00:44.646Z",
+      "firebaseKey": "-MPQdeqiBtHSzZ6FsAG_",
+      "hidden": true,
+      "requestedTime": "Fri, 25 Dec 2020",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MQFPbGyz5C0wmGK3is6",
+      "status": "pending",
+      "taskId": "-MOoDVOnKe6HnlPhEQVQ",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MQAWljEW0dHJVYs5EwB": {
+      "completedTime": "2021-01-05T03:32:32.042Z",
+      "firebaseKey": "-MQAWljEW0dHJVYs5EwB",
+      "hidden": true,
+      "requestedTime": "Sun Jan 03 2021",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MQFars5_aXDDXaHpmLb",
+      "status": "pending",
+      "taskId": "-MOoDVOnKe6HnlPhEQVQ",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MQFfF4OAECwlND7XqI-": {
+      "completedTime": "2021-01-05T04:09:43.972Z",
+      "firebaseKey": "-MQFfF4OAECwlND7XqI-",
+      "hidden": true,
+      "requestedTime": "Mon Jan 04 2021",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MQFjRLR37YNri3-_HCB",
+      "status": "pending",
+      "taskId": "-MP6rXExf5Rn-JGgBalR",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MQFjpNjeZszVtFmf_8-": {
+      "completedTime": "2021-01-05T04:12:51.962Z",
+      "firebaseKey": "-MQFjpNjeZszVtFmf_8-",
+      "hidden": true,
+      "requestedTime": "Mon Jan 04 2021",
+      "requesterId": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2",
+      "reviewId": "-MQFkBDnJ19qBzMFWKen",
+      "status": "pending",
+      "taskId": "-MOv_w_YC27s7sPt9GQK",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MQFjpRiiHIcAgKe43Bw": {
+      "completedTime": "2021-01-05T04:13:19.272Z",
+      "firebaseKey": "-MQFjpRiiHIcAgKe43Bw",
+      "hidden": true,
+      "requestedTime": "Mon Jan 04 2021",
+      "requesterId": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2",
+      "reviewId": "-MQFkFG8uOtxCEwilKrO",
+      "status": "pending",
+      "taskId": "-MOdLx-YJQdtYIyaCHnZ",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MQIYTQg5PvxcLh6q7zC": {
+      "completedTime": "2021-01-06T00:22:25.455Z",
+      "firebaseKey": "-MQIYTQg5PvxcLh6q7zC",
+      "hidden": true,
+      "requestedTime": "Tue Jan 05 2021",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MQrFypMeEEWkpH94X4O",
+      "status": "pending",
+      "taskId": "-MOdJuQoyPb_TS91zzUy",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MQK3zcLir4ourxlEWbC": {
+      "completedTime": "2021-01-06T00:23:45.369Z",
+      "firebaseKey": "-MQK3zcLir4ourxlEWbC",
+      "hidden": true,
+      "requestedTime": "Tue Jan 05 2021",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MQK49f-c-4jjKoZ0Whk",
+      "status": "pending",
+      "taskId": "-MOdJuQoyPb_TS91zzUy",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MSrvbsyvqcSqqH5l8YT": {
+      "completedTime": "2021-02-06T15:20:55.400Z",
+      "firebaseKey": "-MSrvbsyvqcSqqH5l8YT",
+      "hidden": true,
+      "requestedTime": "Sat Feb 06 2021",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "-MSrw-65xYq9ufKAbnx1",
+      "status": "pending",
+      "taskId": "-MOdJuQoyPb_TS91zzUy",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-MczsOPl4cU2KeJV-1cF": {
+      "completedTime": "",
+      "firebaseKey": "-MczsOPl4cU2KeJV-1cF",
+      "requestedTime": "Thu Jun 24 2021",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "",
+      "status": "pending",
+      "taskId": "-MOoDVOnKe6HnlPhEQVQ",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    },
+    "-NLRtlpJW8XrzssyHyqP": {
+      "completedTime": "",
+      "firebaseKey": "-NLRtlpJW8XrzssyHyqP",
+      "requestedTime": "Tue Jan 10 2023",
+      "requesterId": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "reviewId": "",
+      "status": "pending",
+      "taskId": "-MP6rXExf5Rn-JGgBalR",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    }
+  },
+  "userjoin": {
+    "-MO9RUJa2tosvt1b4TUR": {
+      "confirm": true,
+      "firebaseKey": "-MO9RUJa2tosvt1b4TUR",
+      "user1FBKey": "Rrc9S98bxCa49bb5W1QEk78e9Uj1",
+      "user2FBKey": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    }
+  },
+  "users": {
+    "-MNonquMPWHyxxRxVVOX": {
+      "email": "user1@example.com",
+      "firebaseKey": "-MNonquMPWHyxxRxVVOX",
+      "image": "",
+      "lastSignInTime": "Sat, 05 Dec 2020 21:29:37 GMT",
+      "name": "Demo User One",
+      "uid": "Rrc9S98bxCa49bb5W1QEk78e9Uj1"
+    },
+    "-MNp4ih1zW3LUReXNbc2": {
+      "email": "user2@example.com",
+      "firebaseKey": "-MNp4ih1zW3LUReXNbc2",
+      "image": "",
+      "lastSignInTime": "Sat, 05 Dec 2020 22:47:42 GMT",
+      "name": "Demo User Two",
+      "uid": "cR1XDfJ1WQWlWgEcHd8rmyK2yVl2"
+    }
+  }
+}

--- a/server/src/seed.ts
+++ b/server/src/seed.ts
@@ -1,0 +1,83 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import mongoose from 'mongoose';
+import { connectToDatabase } from './db';
+import { Service } from './models/Service';
+import { User } from './models/User';
+import { ToDo } from './models/ToDo';
+import { Review } from './models/Review';
+import { UserJoin } from './models/UserJoin';
+
+interface FirebaseExport {
+  users?: Record<string, unknown>;
+  services?: Record<string, unknown>;
+  todo?: Record<string, unknown>;
+  review?: Record<string, unknown>;
+  userjoin?: Record<string, unknown>;
+}
+
+// Real export is gitignored (real emails); the demo file is committed + anonymized.
+const realDataPath = fileURLToPath(new URL('../../migration/firebase-export.json', import.meta.url));
+const demoDataPath = fileURLToPath(new URL('./seed-data.demo.json', import.meta.url));
+
+function resolveSource(): { path: string; mode: 'real' | 'demo' } {
+  const mode = process.env.SEED_MODE;
+  if (mode === 'demo') return { path: demoDataPath, mode: 'demo' };
+  if (mode === 'real') return { path: realDataPath, mode: 'real' };
+  // Default: use real data if it's present locally, otherwise the committed demo.
+  if (existsSync(realDataPath)) return { path: realDataPath, mode: 'real' };
+  return { path: demoDataPath, mode: 'demo' };
+}
+
+// Map each record so its Mongo _id IS the Firebase push-id (firebaseKey), keeping
+// all cross-references valid. Records with a blank firebaseKey get a generated id.
+const toDocs = (obj?: Record<string, unknown>): Record<string, unknown>[] =>
+  obj
+    ? Object.values(obj).map((d) => {
+        const { firebaseKey, ...rest } = d as Record<string, unknown>;
+        return firebaseKey ? { _id: firebaseKey, ...rest } : rest;
+      })
+    : [];
+
+/** Idempotent: clears the collections and re-inserts from the chosen source. */
+export async function seedDatabase(): Promise<void> {
+  const { path, mode } = resolveSource();
+  const data = JSON.parse(readFileSync(path, 'utf-8')) as FirebaseExport;
+
+  await Promise.all([
+    User.deleteMany({}),
+    Service.deleteMany({}),
+    ToDo.deleteMany({}),
+    Review.deleteMany({}),
+    UserJoin.deleteMany({}),
+  ]);
+
+  const [users, services, todos, reviews, joins] = await Promise.all([
+    User.insertMany(toDocs(data.users)),
+    Service.insertMany(toDocs(data.services)),
+    ToDo.insertMany(toDocs(data.todo)),
+    Review.insertMany(toDocs(data.review)),
+    UserJoin.insertMany(toDocs(data.userjoin)),
+  ]);
+
+  console.log(
+    `[seed] mode=${mode} -> users:${users.length} services:${services.length} ` +
+      `todos:${todos.length} reviews:${reviews.length} joins:${joins.length}`,
+  );
+}
+
+// `npm run seed` — connect, seed, disconnect. Use this against a real/persistent
+// DB (Docker/Cosmos). For the in-memory DB, seeding happens on server startup.
+const isDirectRun = process.argv[1] === fileURLToPath(import.meta.url);
+if (isDirectRun) {
+  (async () => {
+    const useMemoryDb = process.env.USE_MEMORY_DB === 'true';
+    await connectToDatabase(useMemoryDb ? undefined : process.env.MONGO_URI);
+    await seedDatabase();
+    await mongoose.disconnect();
+    process.exit(0);
+  })().catch((err) => {
+    console.error('[seed] failed:', err);
+    process.exit(1);
+  });
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/src/data/apiRoutes.ts
+++ b/src/data/apiRoutes.ts
@@ -1,20 +1,22 @@
-// Centralized Firebase REST endpoint strings (all paths end in `.json`).
+// Express API endpoint strings (relative to VITE_API_BASE_URL). Records are
+// addressed by `firebaseKey`, which the server uses as the document _id.
 export const apiRoutes = {
-  services: '/services.json',
-  service: (key: string) => `/services/${key}.json`,
-  servicesByUid: (uid: string) => `/services.json?orderBy="uid"&equalTo="${uid}"`,
+  services: '/services',
+  service: (key: string) => `/services/${key}`,
+  servicesByUid: (uid: string) => `/services?uid=${uid}`,
 
-  todos: '/todo.json',
-  todo: (key: string) => `/todo/${key}.json`,
-  todosByUid: (uid: string) => `/todo.json?orderBy="uid"&equalTo="${uid}"`,
+  todos: '/todos',
+  todo: (key: string) => `/todos/${key}`,
+  todosByUid: (uid: string) => `/todos?uid=${uid}`,
 
-  reviews: '/review.json',
-  review: (key: string) => `/review/${key}.json`,
+  reviews: '/reviews',
+  review: (key: string) => `/reviews/${key}`,
 
-  users: '/users.json',
-  user: (key: string) => `/users/${key}.json`,
-  usersByUid: (uid: string) => `/users.json?orderBy="uid"&equalTo="${uid}"`,
+  users: '/users',
+  user: (key: string) => `/users/${key}`,
+  usersByUid: (uid: string) => `/users?uid=${uid}`,
 
-  userJoins: '/userjoin.json',
-  userJoin: (key: string) => `/userjoin/${key}.json`,
+  userJoins: '/userjoins',
+  userJoin: (key: string) => `/userjoins/${key}`,
+  userJoinsByUid: (uid: string) => `/userjoins?uid=${uid}`,
 };

--- a/src/data/useAPIRequest.ts
+++ b/src/data/useAPIRequest.ts
@@ -1,8 +1,7 @@
 import { useCallback } from 'react';
-import firebaseConfig from '../helpers/apiKeys';
 
-// Firebase Realtime Database REST endpoint. All paths end in `.json`.
-const baseUrl = firebaseConfig.databaseURL;
+// Express API base (MERN). e.g. http://localhost:4000/api
+const baseUrl = import.meta.env.VITE_API_BASE_URL;
 
 interface RequestOptions {
   successMessage?: string;

--- a/src/data/useLeaderboardData.ts
+++ b/src/data/useLeaderboardData.ts
@@ -8,10 +8,7 @@ export function useTaskLeaderboard(uid: string) {
   const { get } = useAPIRequest();
   return useQuery<TaskCompletion>(
     ['taskLeaderboard', uid],
-    async () => {
-      const data = await get<Record<string, ToDo> | null>(apiRoutes.todosByUid(uid));
-      return calcTaskCompletion(data ? Object.values(data) : []);
-    },
+    async () => calcTaskCompletion(await get<ToDo[]>(apiRoutes.todosByUid(uid))),
     { enabled: Boolean(uid) },
   );
 }

--- a/src/data/useReviewData.ts
+++ b/src/data/useReviewData.ts
@@ -5,24 +5,25 @@ import type { Review } from '../types';
 
 export function useAllReviews() {
   const { get } = useAPIRequest();
-  return useQuery<Record<string, Review>>(
-    ['reviews'],
-    async () => (await get<Record<string, Review> | null>(apiRoutes.reviews)) ?? {},
-  );
+  // Keyed by firebaseKey to match the existing consumers (they Object.values it).
+  return useQuery<Record<string, Review>>(['reviews'], async () => {
+    const list = await get<Review[]>(apiRoutes.reviews);
+    return Object.fromEntries(list.map((r) => [r.firebaseKey, r]));
+  });
 }
 
 export function useCreateReview() {
   const { post, patch } = useAPIRequest();
   const queryClient = useQueryClient();
-  return useMutation<unknown, Error, Review>(
+  return useMutation<Review, Error, Review>(
     async (review) => {
-      const res = await post<{ name: string }>(apiRoutes.reviews, review, {
+      const created = await post<Review>(apiRoutes.reviews, review, {
         successMessage: 'Review submitted.',
         errorMessage: 'Review not submitted.',
       });
-      await patch(apiRoutes.review(res.name), { firebaseKey: res.name });
-      // mark the related todo reviewed
-      return patch(apiRoutes.todo(review.toDoid), { reviewId: res.name });
+      // Mark the related todo reviewed (links it to this review).
+      await patch(apiRoutes.todo(review.toDoid), { reviewId: created.firebaseKey });
+      return created;
     },
     {
       onSuccess: () => {

--- a/src/data/useServiceData.ts
+++ b/src/data/useServiceData.ts
@@ -5,17 +5,18 @@ import type { Service } from '../types';
 
 export function useAllServices() {
   const { get } = useAPIRequest();
-  return useQuery<Service[]>(['services'], async () => {
-    const data = await get<Record<string, Service> | null>(apiRoutes.services);
-    return data ? Object.values(data) : [];
-  });
+  return useQuery<Service[]>(['services'], () => get<Service[]>(apiRoutes.services));
 }
 
 export function useUserServices(uid: string) {
   const { get } = useAPIRequest();
+  // Returned keyed by firebaseKey because some callers do services[key].
   return useQuery<Record<string, Service>>(
     ['userServices', uid],
-    async () => (await get<Record<string, Service> | null>(apiRoutes.servicesByUid(uid))) ?? {},
+    async () => {
+      const list = await get<Service[]>(apiRoutes.servicesByUid(uid));
+      return Object.fromEntries(list.map((s) => [s.firebaseKey, s]));
+    },
     { enabled: Boolean(uid) },
   );
 }
@@ -25,8 +26,8 @@ export function useServiceByKey(fbKey: string) {
   return useQuery<Service | undefined>(
     ['serviceByKey', fbKey],
     async () => {
-      const data = await get<Record<string, Service> | null>(apiRoutes.services);
-      return data ? Object.values(data).find((s) => s.firebaseKey === fbKey) : undefined;
+      const list = await get<Service[]>(apiRoutes.services);
+      return list.find((s) => s.firebaseKey === fbKey);
     },
     { enabled: Boolean(fbKey) },
   );
@@ -38,16 +39,14 @@ const invalidateServices = (queryClient: ReturnType<typeof useQueryClient>) => {
 };
 
 export function useCreateService() {
-  const { post, patch } = useAPIRequest();
+  const { post } = useAPIRequest();
   const queryClient = useQueryClient();
-  return useMutation<unknown, Error, Service>(
-    async (service) => {
-      const res = await post<{ name: string }>(apiRoutes.services, service, {
+  return useMutation<Service, Error, Service>(
+    (service) =>
+      post<Service>(apiRoutes.services, service, {
         successMessage: 'Service created.',
         errorMessage: 'Service not created.',
-      });
-      return patch(apiRoutes.service(res.name), { firebaseKey: res.name });
-    },
+      }),
     { onSuccess: () => invalidateServices(queryClient) },
   );
 }
@@ -55,9 +54,9 @@ export function useCreateService() {
 export function useUpdateService() {
   const { patch } = useAPIRequest();
   const queryClient = useQueryClient();
-  return useMutation<unknown, Error, Service>(
+  return useMutation<Service, Error, Service>(
     (service) =>
-      patch(apiRoutes.service(service.firebaseKey), service, {
+      patch<Service>(apiRoutes.service(service.firebaseKey), service, {
         successMessage: 'Service updated.',
         errorMessage: 'Service not updated.',
       }),

--- a/src/data/useTodoData.ts
+++ b/src/data/useTodoData.ts
@@ -6,24 +6,16 @@ import type { ToDo } from '../types';
 
 export function useUserTodos(uid: string) {
   const { get } = useAPIRequest();
-  return useQuery<ToDo[]>(
-    ['todos', uid],
-    async () => {
-      const data = await get<Record<string, ToDo> | null>(apiRoutes.todosByUid(uid));
-      return data ? Object.values(data) : [];
-    },
-    { enabled: Boolean(uid) },
-  );
+  return useQuery<ToDo[]>(['todos', uid], () => get<ToDo[]>(apiRoutes.todosByUid(uid)), {
+    enabled: Boolean(uid),
+  });
 }
 
 export function useCompletedUnreviewed(uid: string) {
   const { get } = useAPIRequest();
   return useQuery<ToDo[]>(
     ['completedUnreviewed', uid],
-    async () => {
-      const data = await get<Record<string, ToDo> | null>(apiRoutes.todosByUid(uid));
-      return filterCompletedUnreviewed(data ? Object.values(data) : []);
-    },
+    async () => filterCompletedUnreviewed(await get<ToDo[]>(apiRoutes.todosByUid(uid))),
     { enabled: Boolean(uid) },
   );
 }
@@ -32,15 +24,11 @@ export function useTodoCounts(uid: string) {
   const { get } = useAPIRequest();
   return useQuery<[string, number][]>(
     ['todoCounts', uid],
-    async () => {
-      const data = await get<Record<string, ToDo> | null>(apiRoutes.todosByUid(uid));
-      return countTodosByTask(data ? Object.values(data) : []);
-    },
+    async () => countTodosByTask(await get<ToDo[]>(apiRoutes.todosByUid(uid))),
     { enabled: Boolean(uid) },
   );
 }
 
-// Any todo write affects the lists, the per-task counts and the leaderboard.
 const invalidateTodos = (queryClient: ReturnType<typeof useQueryClient>) => {
   queryClient.invalidateQueries(['todos']);
   queryClient.invalidateQueries(['completedUnreviewed']);
@@ -49,15 +37,10 @@ const invalidateTodos = (queryClient: ReturnType<typeof useQueryClient>) => {
 };
 
 export function useCreateToDo() {
-  const { post, patch } = useAPIRequest();
+  const { post } = useAPIRequest();
   const queryClient = useQueryClient();
-  return useMutation<unknown, Error, ToDo>(
-    async (todo) => {
-      const res = await post<{ name: string }>(apiRoutes.todos, todo, {
-        successMessage: 'Request created.',
-      });
-      return patch(apiRoutes.todo(res.name), { firebaseKey: res.name });
-    },
+  return useMutation<ToDo, Error, ToDo>(
+    (todo) => post<ToDo>(apiRoutes.todos, todo, { successMessage: 'Request created.' }),
     { onSuccess: () => invalidateTodos(queryClient) },
   );
 }

--- a/src/data/useUserData.ts
+++ b/src/data/useUserData.ts
@@ -5,10 +5,11 @@ import type { User, UserJoin } from '../types';
 
 export function useAllUsers() {
   const { get } = useAPIRequest();
-  return useQuery<Record<string, User>>(
-    ['users'],
-    async () => (await get<Record<string, User> | null>(apiRoutes.users)) ?? {},
-  );
+  // Keyed by firebaseKey to match the existing consumers (they Object.values it).
+  return useQuery<Record<string, User>>(['users'], async () => {
+    const list = await get<User[]>(apiRoutes.users);
+    return Object.fromEntries(list.map((u) => [u.firebaseKey, u]));
+  });
 }
 
 const invalidateJoins = (queryClient: ReturnType<typeof useQueryClient>) => {
@@ -17,15 +18,10 @@ const invalidateJoins = (queryClient: ReturnType<typeof useQueryClient>) => {
 };
 
 export function useCreateUserJoin() {
-  const { post, patch } = useAPIRequest();
+  const { post } = useAPIRequest();
   const queryClient = useQueryClient();
-  return useMutation<unknown, Error, UserJoin>(
-    async (userJoin) => {
-      const res = await post<{ name: string }>(apiRoutes.userJoins, userJoin, {
-        successMessage: 'Link request sent.',
-      });
-      return patch(apiRoutes.userJoin(res.name), { firebaseKey: res.name });
-    },
+  return useMutation<UserJoin, Error, UserJoin>(
+    (userJoin) => post<UserJoin>(apiRoutes.userJoins, userJoin, { successMessage: 'Link request sent.' }),
     { onSuccess: () => invalidateJoins(queryClient) },
   );
 }

--- a/src/helpers/data/apiClient.ts
+++ b/src/helpers/data/apiClient.ts
@@ -1,7 +1,5 @@
-import firebaseConfig from '../apiKeys';
-
-// Firebase Realtime Database REST endpoint. All paths end in `.json`.
-const baseUrl = firebaseConfig.databaseURL;
+// Express API base (MERN). Used by the imperative auth bootstrap in <App>.
+const baseUrl = import.meta.env.VITE_API_BASE_URL;
 
 type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 

--- a/src/helpers/data/userData.ts
+++ b/src/helpers/data/userData.ts
@@ -3,18 +3,15 @@
 
 import firebase from 'firebase/app';
 import { apiRequest } from './apiClient';
-import { filterJoinedUsersByUid } from '../../Helper/UserDataHelper';
 import type { User, UserJoin } from '../../types';
 
 type NewUser = Omit<User, 'firebaseKey'>;
 
 const checkIfUserExistsInFirebase = (user: NewUser): void => {
-  apiRequest<Record<string, User> | null>(`/users.json?orderBy="uid"&equalTo="${user.uid}"`)
-    .then((data) => {
-      if (!data || Object.values(data).length === 0) {
-        apiRequest<{ name: string }>('/users.json', 'POST', user)
-          .then((res) => apiRequest(`/users/${res.name}.json`, 'PATCH', { firebaseKey: res.name }))
-          .catch((error) => console.warn(error));
+  apiRequest<User[]>(`/users?uid=${user.uid}`)
+    .then((existing) => {
+      if (!existing || existing.length === 0) {
+        apiRequest('/users', 'POST', user).catch((error) => console.warn(error));
       } else {
         console.warn('User Already Exists');
       }
@@ -23,15 +20,14 @@ const checkIfUserExistsInFirebase = (user: NewUser): void => {
     .catch((error) => console.error(error));
 };
 
-const getJoinedUser = (UID: string) =>
-  apiRequest<Record<string, UserJoin> | null>('/userjoin.json').then((data) =>
-    filterJoinedUsersByUid(data ? Object.values(data) : [], UID),
-  );
+// The server filters joins to those where the uid is either participant.
+const getJoinedUser = (UID: string) => apiRequest<UserJoin[]>(`/userjoins?uid=${UID}`);
 
+// Returned as [firebaseKey, user] entries to match the existing <App> usage.
 const getUserByUid = (uid: string) =>
-  apiRequest<Record<string, User> | null>(
-    `/users.json?orderBy="uid"&equalTo="${uid}"`,
-  ).then((data) => (data ? Object.entries(data) : []));
+  apiRequest<User[]>(`/users?uid=${uid}`).then((list) =>
+    (list ?? []).map((u) => [u.firebaseKey, u] as [string, User]),
+  );
 
 const setCurrentUser = (userObj: firebase.User): NewUser => {
   const user: NewUser = {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL: string;
   readonly VITE_API_KEY: string;
   readonly VITE_AUTH_DOMAIN: string;
   readonly VITE_DATABASE_URL: string;


### PR DESCRIPTION
…ebase

Backend (new server/):
- Express + TypeScript + Mongoose; in-process MongoDB (mongodb-memory-server) for zero-setup local dev, swappable to a real MONGO_URI (Docker/Cosmos) later
- 5 Mongoose models (Service, ToDo, Review, User, UserJoin) where _id holds the legacy firebaseKey (exposed as a virtual) so existing references stay valid
- CRUD routers for all 5 collections with ?uid filtering
- Seed: real local export if present (gitignored), else committed anonymized seed-data.demo.json; auto-seeds the in-memory DB on startup
- asyncHandler + central error middleware; CORS for the Vite app

Frontend:
- Data layer (useAPIRequest/apiRoutes + React Query hooks) now targets the Express API via VITE_API_BASE_URL instead of Firebase REST
- App auth bootstrap (apiClient/userData) repointed to Express
- Firebase now used for sign-in only (auth swap deferred)

tsc clean (client + server); endpoints verified returning seeded data.